### PR TITLE
Removed `themes` object, overrode color tailwind classes

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,9 +1,6 @@
 module.exports = {
   purge: ['./src/**/*.svelte', './src/**/*.css'],
   darkMode: false,
-  theme: {
-    colors: {},
-  },
   variants: {
     extend: {},
   },


### PR DESCRIPTION
```
themes: {
   colors: {},
},
```

This object block in `tailwind.config.cjs` overrode some tailwind color classes (eg. `bg-green-100`). Therefore, removed. 